### PR TITLE
feat: add stats page

### DIFF
--- a/src/app/components/main-nav.tsx
+++ b/src/app/components/main-nav.tsx
@@ -23,8 +23,8 @@ export function MainNav() {
             <NavigationMenuTrigger className="px-2 cursor-pointer">MENU 1</NavigationMenuTrigger>
             <NavigationMenuContent>
               <ul className="grid gap-3 p-6 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
-                <ListItem href="/" title="Haven’t figured it out yet, but I’ll update when I do!">
-                  ไว้ทำจะมาอัพเดทครับ ตอนนี้ยังคิดไม่ออก
+                <ListItem href="/stats" title="สถิติความสำเร็จ">
+                  ดูจำนวนงานที่ทำเสร็จแล้วของคุณ
                 </ListItem>
                 <ListItem href="/" title="Haven’t figured it out yet, but I’ll update when I do!">
                   ไว้ทำจะมาอัพเดทครับ ตอนนี้ยังคิดไม่ออก

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -1,0 +1,33 @@
+import { auth } from '@/auth'
+import { prisma } from '@/prisma'
+
+export default async function Page() {
+  const session = await auth()
+  const email = session?.user?.email
+
+  if (!email) {
+    return (
+      <main className="max-w-lg mx-auto p-6">
+        <h1 className="text-3xl mb-4 text-center">สถิติความสำเร็จ</h1>
+        <p className="text-center">Please login to view your stats</p>
+      </main>
+    )
+  }
+
+  const todos = await prisma.dota2.findMany({
+    where: { userEmail: email },
+  })
+
+  const total = todos.length
+  const completed = todos.filter(t => t.completed).length
+
+  return (
+    <main className="max-w-lg mx-auto p-6">
+      <h1 className="text-3xl mb-4 text-center">สถิติความสำเร็จ</h1>
+      <div className="space-y-2 text-center">
+        <p>งานทั้งหมด: {total}</p>
+        <p>ทำเสร็จแล้ว: {completed}</p>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add basic `/stats` page showing total and completed tasks
- link stats page in main navigation menu

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad832b78588325beab6ee1b2cdb6ab