### PR TITLE
feat: add blog page and improve stats UI

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,33 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+const posts = [
+  {
+    title: 'โพสต์แรก',
+    content: 'ยินดีต้อนรับสู่บล็อกของเรา! นี่คือโพสต์แรกทดลองระบบ'
+  },
+  {
+    title: 'โพสต์ถัดไป',
+    content: 'ในอนาคตจะมีเนื้อหาสาระมาอัปเดตที่นี่เรื่อย ๆ'
+  }
+]
+
+export default function BlogPage() {
+  return (
+    <main className="max-w-2xl mx-auto p-6 space-y-6">
+      <h1 className="text-3xl text-center">บล็อก</h1>
+      <div className="space-y-4">
+        {posts.map((post, idx) => (
+          <Card key={idx}>
+            <CardHeader>
+              <CardTitle>{post.title}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p>{post.content}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </main>
+  )
+}
+

--- a/src/app/components/main-nav.tsx
+++ b/src/app/components/main-nav.tsx
@@ -26,8 +26,8 @@ export function MainNav() {
                 <ListItem href="/stats" title="สถิติความสำเร็จ">
                   ดูจำนวนงานที่ทำเสร็จแล้วของคุณ
                 </ListItem>
-                <ListItem href="/" title="Haven’t figured it out yet, but I’ll update when I do!">
-                  ไว้ทำจะมาอัพเดทครับ ตอนนี้ยังคิดไม่ออก
+                <ListItem href="/blog" title="บล็อก">
+                  อ่านโพสต์บทความต่างๆ
                 </ListItem>
                 <ListItem href="/" title="Haven’t figured it out yet, but I’ll update when I do!">
                   ไว้ทำจะมาอัพเดทครับ ตอนนี้ยังคิดไม่ออก

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -1,5 +1,6 @@
 import { auth } from '@/auth'
 import { prisma } from '@/prisma'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
 export default async function Page() {
   const session = await auth()
@@ -21,12 +22,30 @@ export default async function Page() {
   const total = todos.length
   const completed = todos.filter(t => t.completed).length
 
+  const pending = total - completed
+
   return (
-    <main className="max-w-lg mx-auto p-6">
-      <h1 className="text-3xl mb-4 text-center">สถิติความสำเร็จ</h1>
-      <div className="space-y-2 text-center">
-        <p>งานทั้งหมด: {total}</p>
-        <p>ทำเสร็จแล้ว: {completed}</p>
+    <main className="max-w-2xl mx-auto p-6">
+      <h1 className="text-3xl mb-6 text-center">สถิติความสำเร็จ</h1>
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Card>
+          <CardHeader className="text-center">
+            <CardTitle>ทั้งหมด</CardTitle>
+          </CardHeader>
+          <CardContent className="text-center text-2xl font-bold">{total}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="text-center">
+            <CardTitle>ทำเสร็จแล้ว</CardTitle>
+          </CardHeader>
+          <CardContent className="text-center text-2xl font-bold text-green-600">{completed}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="text-center">
+            <CardTitle>ค้างอยู่</CardTitle>
+          </CardHeader>
+          <CardContent className="text-center text-2xl font-bold text-red-600">{pending}</CardContent>
+        </Card>
       </div>
     </main>
   )


### PR DESCRIPTION
## Summary
- add simple blog page with placeholder posts
- link blog in main navigation
- restyle stats page using cards for totals

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad90acc1b08325937495451d181daa