### PR TITLE
feat: add blog page and improve stats UI

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,9 +11,18 @@ model Dota2 {
   title       String
   description String?
   completed   Boolean  @default(false)
-  userEmail   String?  
+  userEmail   String?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
+}
+
+model Post {
+  id        String   @id @default(auto()) @map("_id") @db.ObjectId
+  title     String
+  content   String?
+  userEmail String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 

--- a/src/app/api/posts/[id]/route.ts
+++ b/src/app/api/posts/[id]/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/prisma'
+import { auth } from '@/auth'
+
+// [GET] - get single post
+export async function GET(req: NextRequest) {
+  const session = await auth()
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const id = req.nextUrl.pathname.split('/').pop()
+  if (!id) {
+    return NextResponse.json({ error: 'Invalid ID' }, { status: 400 })
+  }
+
+  try {
+    const post = await prisma.post.findUnique({ where: { id } })
+    return NextResponse.json(post)
+  } catch (error) {
+    console.error('GET /api/posts/[id] error:', error)
+    return NextResponse.json({ error: 'Failed to fetch post' }, { status: 500 })
+  }
+}
+
+// [PUT] - update post
+export async function PUT(req: NextRequest) {
+  const session = await auth()
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const id = req.nextUrl.pathname.split('/').pop()
+  if (!id) {
+    return NextResponse.json({ error: 'Invalid ID' }, { status: 400 })
+  }
+
+  try {
+    const body = await req.json()
+    const { title, content } = body
+
+    await prisma.post.update({
+      where: { id },
+      data: { title, content },
+    })
+
+    return NextResponse.json({ message: 'Updated successfully' })
+  } catch (error) {
+    console.error('PUT /api/posts/[id] error:', error)
+    return NextResponse.json({ error: 'Failed to update post' }, { status: 500 })
+  }
+}
+
+// [DELETE] - delete post
+export async function DELETE(req: NextRequest) {
+  const session = await auth()
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const id = req.nextUrl.pathname.split('/').pop()
+  if (!id) {
+    return NextResponse.json({ error: 'Invalid ID' }, { status: 400 })
+  }
+
+  try {
+    await prisma.post.delete({ where: { id } })
+    return NextResponse.json({ message: 'Deleted successfully' })
+  } catch (error) {
+    console.error('DELETE /api/posts/[id] error:', error)
+    return NextResponse.json({ error: 'Failed to delete post' }, { status: 500 })
+  }
+}

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/prisma'
+import { auth } from '@/auth'
+
+// [GET] - fetch all posts
+export async function GET() {
+  const session = await auth()
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const posts = await prisma.post.findMany({
+      where: { userEmail: session.user?.email || undefined },
+      orderBy: { createdAt: 'desc' },
+    })
+    return NextResponse.json(posts)
+  } catch (error) {
+    console.error('GET /api/posts error:', error)
+    return NextResponse.json({ error: 'Failed to fetch posts' }, { status: 500 })
+  }
+}
+
+// [POST] - create new post
+export async function POST(req: NextRequest) {
+  const session = await auth()
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const body = await req.json()
+    const { title, content } = body
+
+    const post = await prisma.post.create({
+      data: {
+        title,
+        content: content || '',
+        userEmail: session.user?.email || undefined,
+      },
+    })
+
+    return NextResponse.json(post)
+  } catch (error) {
+    console.error('POST /api/posts error:', error)
+    return NextResponse.json({ error: 'Failed to create post' }, { status: 500 })
+  }
+}

--- a/src/app/blog/BlogList.tsx
+++ b/src/app/blog/BlogList.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { toast } from 'sonner'
+
+export type BlogPost = {
+  id: string
+  title: string
+  content: string | null
+}
+
+type Props = {
+  posts: BlogPost[]
+}
+
+export default function BlogList({ posts: initialPosts }: Props) {
+  const [posts, setPosts] = useState(initialPosts)
+
+  const handleDelete = async (id: string) => {
+    const res = await fetch(`/api/posts/${id}`, { method: 'DELETE' })
+    if (res.ok) {
+      setPosts(posts.filter(p => p.id !== id))
+      toast('ลบโพสต์แล้ว 🗑️')
+    } else {
+      toast('ลบโพสต์ไม่สำเร็จ ❌')
+    }
+  }
+
+  if (posts.length === 0) {
+    return <p className="text-center">ยังไม่มีโพสต์</p>
+  }
+
+  return (
+    <div className="space-y-4">
+      {posts.map(post => (
+        <Card key={post.id}>
+          <CardHeader className="flex justify-between items-center">
+            <CardTitle>{post.title}</CardTitle>
+            <div className="space-x-2">
+              <Button asChild variant="outline" size="sm">
+                <Link href={`/blog/${post.id}/edit`}>แก้ไข</Link>
+              </Button>
+              <Button variant="destructive" size="sm" onClick={() => handleDelete(post.id)}>
+                ลบ
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <p>{post.content}</p>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}

--- a/src/app/blog/EditPostForm.tsx
+++ b/src/app/blog/EditPostForm.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import { toast } from 'sonner'
+
+type Props = {
+  id: string
+  title: string
+  content: string | null
+}
+
+export default function EditPostForm({ id, title: initialTitle, content: initialContent }: Props) {
+  const [title, setTitle] = useState(initialTitle)
+  const [content, setContent] = useState(initialContent || '')
+  const router = useRouter()
+
+  const submit = async () => {
+    const res = await fetch(`/api/posts/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, content }),
+    })
+
+    if (res.ok) {
+      toast('อัปเดตโพสต์แล้ว ✏️')
+      router.push('/blog')
+      router.refresh()
+    } else {
+      toast('อัปเดตโพสต์ไม่สำเร็จ ❌')
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <Input value={title} onChange={e => setTitle(e.target.value)} />
+      <Textarea value={content} onChange={e => setContent(e.target.value)} />
+      <Button onClick={submit}>บันทึก</Button>
+    </div>
+  )
+}

--- a/src/app/blog/NewPostForm.tsx
+++ b/src/app/blog/NewPostForm.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import { toast } from 'sonner'
+
+type Props = {
+  userEmail: string
+}
+
+export default function NewPostForm({ userEmail }: Props) {
+  const [title, setTitle] = useState('')
+  const [content, setContent] = useState('')
+  const router = useRouter()
+
+  const submit = async () => {
+    const res = await fetch('/api/posts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, content, userEmail }),
+    })
+
+    if (res.ok) {
+      toast('สร้างโพสต์แล้ว ✅')
+      router.push('/blog')
+      router.refresh()
+    } else {
+      toast('สร้างโพสต์ไม่สำเร็จ ❌')
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <Input value={title} onChange={e => setTitle(e.target.value)} placeholder="หัวข้อ" />
+      <Textarea value={content} onChange={e => setContent(e.target.value)} placeholder="เนื้อหา" />
+      <Button onClick={submit}>บันทึก</Button>
+    </div>
+  )
+}

--- a/src/app/blog/[id]/edit/page.tsx
+++ b/src/app/blog/[id]/edit/page.tsx
@@ -1,0 +1,36 @@
+import { auth } from '@/auth'
+import { prisma } from '@/prisma'
+import EditPostForm from '../../EditPostForm'
+
+type Props = {
+  params: { id: string }
+}
+
+export default async function EditPage({ params }: Props) {
+  const session = await auth()
+
+  if (!session) {
+    return (
+      <main className="max-w-2xl mx-auto p-6">
+        <p className="text-center">กรุณาเข้าสู่ระบบก่อน</p>
+      </main>
+    )
+  }
+
+  const post = await prisma.post.findUnique({ where: { id: params.id } })
+
+  if (!post) {
+    return (
+      <main className="max-w-2xl mx-auto p-6">
+        <p className="text-center">ไม่พบโพสต์</p>
+      </main>
+    )
+  }
+
+  return (
+    <main className="max-w-2xl mx-auto p-6 space-y-6">
+      <h1 className="text-3xl">แก้ไขโพสต์</h1>
+      <EditPostForm id={post.id} title={post.title} content={post.content} />
+    </main>
+  )
+}

--- a/src/app/blog/new/page.tsx
+++ b/src/app/blog/new/page.tsx
@@ -1,0 +1,31 @@
+import { auth } from '@/auth'
+import NewPostForm from '../NewPostForm'
+
+export default async function NewPostPage() {
+  const session = await auth()
+
+  if (!session) {
+    return (
+      <main className="max-w-2xl mx-auto p-6">
+        <p className="text-center">กรุณาเข้าสู่ระบบก่อน</p>
+      </main>
+    )
+  }
+
+  const email = session.user?.email
+
+  if (!email) {
+    return (
+      <main className="max-w-2xl mx-auto p-6">
+        <p className="text-center">ไม่พบอีเมลผู้ใช้</p>
+      </main>
+    )
+  }
+
+  return (
+    <main className="max-w-2xl mx-auto p-6 space-y-6">
+      <h1 className="text-3xl">สร้างโพสต์</h1>
+      <NewPostForm userEmail={email} />
+    </main>
+  )
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link'
+import { auth } from '@/auth'
+import { prisma } from '@/prisma'
+import BlogList from './BlogList'
+import { Button } from '@/components/ui/button'
+
+export default async function BlogPage() {
+  const session = await auth()
+
+  if (!session) {
+    return (
+      <main className="max-w-2xl mx-auto p-6">
+        <p className="text-center">กรุณาเข้าสู่ระบบเพื่อดูโพสต์</p>
+      </main>
+    )
+  }
+
+  const posts = await prisma.post.findMany({
+    where: { userEmail: session.user?.email || undefined },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  return (
+    <main className="max-w-2xl mx-auto p-6 space-y-6">
+      <div className="flex justify-between items-center">
+        <h1 className="text-3xl">บล็อก</h1>
+        <Button asChild>
+          <Link href="/blog/new">สร้างโพสต์</Link>
+        </Button>
+      </div>
+      <BlogList posts={posts} />
+    </main>
+  )
+}
+

--- a/src/app/components/main-nav.tsx
+++ b/src/app/components/main-nav.tsx
@@ -26,8 +26,8 @@ export function MainNav() {
                 <ListItem href="/stats" title="สถิติความสำเร็จ">
                   ดูจำนวนงานที่ทำเสร็จแล้วของคุณ
                 </ListItem>
-                <ListItem href="/" title="Haven’t figured it out yet, but I’ll update when I do!">
-                  ไว้ทำจะมาอัพเดทครับ ตอนนี้ยังคิดไม่ออก
+                <ListItem href="/blog" title="บล็อก">
+                  อ่านโพสต์บทความต่างๆ
                 </ListItem>
                 <ListItem href="/" title="Haven’t figured it out yet, but I’ll update when I do!">
                   ไว้ทำจะมาอัพเดทครับ ตอนนี้ยังคิดไม่ออก

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -1,5 +1,6 @@
 import { auth } from '@/auth'
 import { prisma } from '@/prisma'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
 export default async function Page() {
   const session = await auth()
@@ -21,12 +22,30 @@ export default async function Page() {
   const total = todos.length
   const completed = todos.filter(t => t.completed).length
 
+  const pending = total - completed
+
   return (
-    <main className="max-w-lg mx-auto p-6">
-      <h1 className="text-3xl mb-4 text-center">สถิติความสำเร็จ</h1>
-      <div className="space-y-2 text-center">
-        <p>งานทั้งหมด: {total}</p>
-        <p>ทำเสร็จแล้ว: {completed}</p>
+    <main className="max-w-2xl mx-auto p-6">
+      <h1 className="text-3xl mb-6 text-center">สถิติความสำเร็จ</h1>
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Card>
+          <CardHeader className="text-center">
+            <CardTitle>ทั้งหมด</CardTitle>
+          </CardHeader>
+          <CardContent className="text-center text-2xl font-bold">{total}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="text-center">
+            <CardTitle>ทำเสร็จแล้ว</CardTitle>
+          </CardHeader>
+          <CardContent className="text-center text-2xl font-bold text-green-600">{completed}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="text-center">
+            <CardTitle>ค้างอยู่</CardTitle>
+          </CardHeader>
+          <CardContent className="text-center text-2xl font-bold text-red-600">{pending}</CardContent>
+        </Card>
       </div>
     </main>
   )


### PR DESCRIPTION
## Summary
- add simple blog page with placeholder posts
- link blog in main navigation
- restyle stats page using cards for totals
- implement full CRUD for blog posts with API routes and forms

## Testing
- `npx prisma generate`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad90acc1b08325937495451d181daa