### PR TITLE
Add game hub pages and APIs

### DIFF
--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server'
+
+const events = [
+  { id: 1, name: 'Spring Tournament', date: '2024-06-01', description: '5v5 battle' },
+  { id: 2, name: 'Summer Fest', date: '2024-07-15', description: 'Co-op quests' },
+]
+
+export async function GET() {
+  return NextResponse.json(events)
+}

--- a/src/app/api/forum/route.ts
+++ b/src/app/api/forum/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+type Post = { id: number; user: string; message: string }
+
+const posts: Post[] = [{ id: 1, user: 'Admin', message: 'Welcome to the forum' }]
+
+export async function GET() {
+  return NextResponse.json(posts)
+}
+
+export async function POST(req: NextRequest) {
+  const { user, message } = await req.json()
+  if (!user || !message) {
+    return NextResponse.json({ error: 'user and message are required' }, { status: 400 })
+  }
+  const post: Post = { id: Date.now(), user, message }
+  posts.push(post)
+  return NextResponse.json(post, { status: 201 })
+}

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+
+type Player = { id: number; name: string; score: number; badges: string[] }
+
+const players: Player[] = [
+  { id: 1, name: 'Alice', score: 1500, badges: ['Champion'] },
+  { id: 2, name: 'Bob', score: 1200, badges: ['Participant'] },
+  { id: 3, name: 'Cindy', score: 900, badges: [] },
+]
+
+export async function GET() {
+  return NextResponse.json([...players].sort((a, b) => b.score - a.score))
+}

--- a/src/app/api/marketplace/route.ts
+++ b/src/app/api/marketplace/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+type Item = { id: number; name: string; image: string; price: number }
+
+const items: Item[] = [
+  { id: 1, name: 'Sword of Dawn', image: '/placeholder.svg', price: 1000 },
+  { id: 2, name: 'Shield of Night', image: '/placeholder.svg', price: 750 },
+]
+
+export async function GET() {
+  return NextResponse.json(items)
+}
+
+export async function POST(req: NextRequest) {
+  const { name, image, price } = await req.json()
+  if (!name || !image || typeof price !== 'number') {
+    return NextResponse.json({ error: 'name, image and price are required' }, { status: 400 })
+  }
+  const item: Item = { id: Date.now(), name, image, price }
+  items.push(item)
+  return NextResponse.json(item, { status: 201 })
+}

--- a/src/app/api/mods/route.ts
+++ b/src/app/api/mods/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+type Mod = { id: number; name: string; description: string; rating: number }
+
+const mods: Mod[] = [
+  { id: 1, name: 'Ultra HD Texture', description: 'Makes game prettier', rating: 5 },
+  { id: 2, name: 'Night Mode', description: 'Adds dark theme', rating: 3 },
+]
+
+export async function GET() {
+  return NextResponse.json(mods)
+}
+
+export async function POST(req: NextRequest) {
+  const { name, description } = await req.json()
+  if (!name || !description) {
+    return NextResponse.json({ error: 'name and description are required' }, { status: 400 })
+  }
+  const mod: Mod = { id: Date.now(), name, description, rating: 0 }
+  mods.push(mod)
+  return NextResponse.json(mod, { status: 201 })
+}
+
+export async function PUT(req: NextRequest) {
+  const { id } = await req.json()
+  const mod = mods.find((m) => m.id === id)
+  if (!mod) {
+    return NextResponse.json({ error: 'mod not found' }, { status: 404 })
+  }
+  mod.rating += 1
+  return NextResponse.json(mod)
+}

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server'
+
+const profile = {
+  name: 'PlayerOne',
+  avatar: '/placeholder.svg',
+  inventory: [
+    { id: 1, name: 'Epic Sword', image: '/placeholder.svg' },
+    { id: 2, name: 'Mystic Wand', image: '/placeholder.svg' },
+  ],
+}
+
+export async function GET() {
+  return NextResponse.json(profile)
+}

--- a/src/app/components/main-nav.tsx
+++ b/src/app/components/main-nav.tsx
@@ -4,7 +4,14 @@ import Image from 'next/image'
 
 import { cn } from '@/lib/utils'
 
-import { NavigationMenu, NavigationMenuContent, NavigationMenuItem, NavigationMenuLink, NavigationMenuList, NavigationMenuTrigger, navigationMenuTriggerStyle } from '@/components/ui/navigation-menu'
+import {
+  NavigationMenu,
+  NavigationMenuContent,
+  NavigationMenuItem,
+  NavigationMenuList,
+  NavigationMenuTrigger,
+  NavigationMenuLink,
+} from '@/components/ui/navigation-menu'
 import React from 'react'
 import { Button } from '@/components/ui/button'
 import CustomLink from './custom-link'
@@ -23,22 +30,26 @@ export function MainNav() {
             <NavigationMenuTrigger className="px-2 cursor-pointer">MENU 1</NavigationMenuTrigger>
             <NavigationMenuContent>
               <ul className="grid gap-3 p-6 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
-                <ListItem href="/" title="Haven’t figured it out yet, but I’ll update when I do!">
-                  ไว้ทำจะมาอัพเดทครับ ตอนนี้ยังคิดไม่ออก
+                <ListItem href="/marketplace" title="Marketplace">
+                  ซื้อขายไอเทมเกมพร้อมค้นหา/กรอง
                 </ListItem>
-                <ListItem href="/" title="Haven’t figured it out yet, but I’ll update when I do!">
-                  ไว้ทำจะมาอัพเดทครับ ตอนนี้ยังคิดไม่ออก
+                <ListItem href="/profile" title="Profile & Inventory">
+                  โปรไฟล์ผู้เล่นและไอเทมที่ถืออยู่
                 </ListItem>
-                <ListItem href="/" title="Haven’t figured it out yet, but I’ll update when I do!">
-                  ไว้ทำจะมาอัพเดทครับ ตอนนี้ยังคิดไม่ออก
+                <ListItem href="/forum" title="Community Forum">
+                  พูดคุยข่าวสารและรีวิวไอเทมเกม
+                </ListItem>
+                <ListItem href="/events" title="Event & Tournament Hub">
+                  ลงทะเบียนและติดตามกิจกรรม
+                </ListItem>
+                <ListItem href="/leaderboard" title="Leaderboard">
+                  จัดอันดับและเก็บสะสม achievement
+                </ListItem>
+                <ListItem href="/mods" title="Mod & Skin Library">
+                  แชร์และให้คะแนน mod หรือ skin
                 </ListItem>
               </ul>
             </NavigationMenuContent>
-          </NavigationMenuItem>
-          <NavigationMenuItem>
-            <NavigationMenuLink href="/todolist" className={navigationMenuTriggerStyle()}>
-              <span>TODO LIST</span>
-            </NavigationMenuLink>
           </NavigationMenuItem>
         </NavigationMenuList>
       </NavigationMenu>
@@ -46,16 +57,25 @@ export function MainNav() {
   )
 }
 
-const ListItem = React.forwardRef<React.ElementRef<'a'>, React.ComponentPropsWithoutRef<'a'>>(({ className, title, children, ...props }, ref) => {
-  return (
-    <li>
-      <NavigationMenuLink asChild>
-        <a ref={ref} className={cn('hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors', className)} {...props}>
-          <div className="text-sm font-medium leading-none">{title}</div>
-          <p className="text-muted-foreground line-clamp-2 text-sm leading-snug">{children}</p>
-        </a>
-      </NavigationMenuLink>
-    </li>
-  )
-})
+const ListItem = React.forwardRef<React.ElementRef<'a'>, React.ComponentPropsWithoutRef<'a'>>(
+  ({ className, title, children, ...props }, ref) => {
+    return (
+      <li>
+        <NavigationMenuLink asChild>
+          <a
+            ref={ref}
+            className={cn(
+              'hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors',
+              className,
+            )}
+            {...props}
+          >
+            <div className="text-sm font-medium leading-none">{title}</div>
+            <p className="text-muted-foreground line-clamp-2 text-sm leading-snug">{children}</p>
+          </a>
+        </NavigationMenuLink>
+      </li>
+    )
+  },
+)
 ListItem.displayName = 'ListItem'

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+type Event = { id: number; name: string; date: string; description: string }
+
+export default function EventsPage() {
+  const [events, setEvents] = useState<Event[]>([])
+
+  useEffect(() => {
+    fetch('/api/events')
+      .then((res) => res.json())
+      .then(setEvents)
+  }, [])
+
+  return (
+    <div className="max-w-xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold">Events & Tournament Hub</h1>
+      <ul className="space-y-2">
+        {events.map((e) => (
+          <li key={e.id} className="border p-2 rounded">
+            <div className="font-semibold">{e.name}</div>
+            <div className="text-sm text-muted-foreground">{e.date}</div>
+            <p className="text-sm">{e.description}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/app/forum/page.tsx
+++ b/src/app/forum/page.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+
+type Post = { id: number; user: string; message: string }
+
+export default function ForumPage() {
+  const [posts, setPosts] = useState<Post[]>([])
+  const [form, setForm] = useState({ user: '', message: '' })
+
+  const fetchPosts = async () => {
+    const res = await fetch('/api/forum')
+    setPosts(await res.json())
+  }
+
+  useEffect(() => {
+    fetchPosts()
+  }, [])
+
+  const submit = async () => {
+    if (!form.user || !form.message) return
+    const res = await fetch('/api/forum', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    })
+    if (res.ok) {
+      setForm({ user: '', message: '' })
+      fetchPosts()
+    }
+  }
+
+  return (
+    <div className="max-w-xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold">Community Forum</h1>
+      <div className="space-y-2">
+        <Input
+          placeholder="Your name"
+          value={form.user}
+          onChange={(e) => setForm({ ...form, user: e.target.value })}
+        />
+        <Textarea
+          placeholder="Message"
+          value={form.message}
+          onChange={(e) => setForm({ ...form, message: e.target.value })}
+        />
+        <Button onClick={submit}>Post</Button>
+      </div>
+      <ul className="space-y-2">
+        {posts.map((p) => (
+          <li key={p.id} className="border p-2 rounded">
+            <div className="font-semibold">{p.user}</div>
+            <div className="text-sm">{p.message}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+type Player = { id: number; name: string; score: number; badges: string[] }
+
+export default function LeaderboardPage() {
+  const [players, setPlayers] = useState<Player[]>([])
+
+  useEffect(() => {
+    fetch('/api/leaderboard')
+      .then((res) => res.json())
+      .then(setPlayers)
+  }, [])
+
+  return (
+    <div className="max-w-md mx-auto space-y-4">
+      <h1 className="text-2xl font-bold">Leaderboard</h1>
+      <ul className="space-y-2">
+        {players.map((p) => (
+          <li key={p.id} className="flex justify-between border p-2 rounded">
+            <div>
+              <div className="font-semibold">{p.name}</div>
+              {p.badges.length > 0 && (
+                <div className="text-xs text-muted-foreground">{p.badges.join(', ')}</div>
+              )}
+            </div>
+            <span>{p.score}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import Image from 'next/image'
+import { useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+type Item = { id: number; name: string; image: string; price: number }
+
+export default function MarketplacePage() {
+  const [items, setItems] = useState<Item[]>([])
+  const [form, setForm] = useState({ name: '', image: '', price: '' })
+
+  const fetchItems = async () => {
+    const res = await fetch('/api/marketplace')
+    setItems(await res.json())
+  }
+
+  useEffect(() => {
+    fetchItems()
+  }, [])
+
+  const postItem = async () => {
+    const price = parseFloat(form.price)
+    if (!form.name || !form.image || isNaN(price)) return
+    const res = await fetch('/api/marketplace', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...form, price }),
+    })
+    if (res.ok) {
+      setForm({ name: '', image: '', price: '' })
+      fetchItems()
+    }
+  }
+
+  return (
+    <div className="max-w-xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold">Marketplace</h1>
+      <div className="flex gap-2">
+        <Input
+          placeholder="Item name"
+          value={form.name}
+          onChange={(e) => setForm({ ...form, name: e.target.value })}
+        />
+        <Input
+          placeholder="Image URL"
+          value={form.image}
+          onChange={(e) => setForm({ ...form, image: e.target.value })}
+        />
+        <Input
+          type="number"
+          placeholder="Price"
+          value={form.price}
+          onChange={(e) => setForm({ ...form, price: e.target.value })}
+        />
+        <Button onClick={postItem}>Post</Button>
+      </div>
+      <ul className="space-y-2">
+        {items.map((item) => (
+          <li key={item.id} className="flex items-center gap-4 border p-2 rounded">
+            <Image src={item.image} alt={item.name} width={40} height={40} className="rounded" />
+            <span className="flex-1">{item.name}</span>
+            <span>{item.price}g</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/app/mods/page.tsx
+++ b/src/app/mods/page.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+
+type Mod = { id: number; name: string; description: string; rating: number }
+
+export default function ModsPage() {
+  const [mods, setMods] = useState<Mod[]>([])
+  const [form, setForm] = useState({ name: '', description: '' })
+
+  const fetchMods = async () => {
+    const res = await fetch('/api/mods')
+    setMods(await res.json())
+  }
+
+  useEffect(() => {
+    fetchMods()
+  }, [])
+
+  const addMod = async () => {
+    if (!form.name || !form.description) return
+    const res = await fetch('/api/mods', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    })
+    if (res.ok) {
+      setForm({ name: '', description: '' })
+      fetchMods()
+    }
+  }
+
+  const rate = async (id: number) => {
+    const res = await fetch('/api/mods', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id }),
+    })
+    if (res.ok) fetchMods()
+  }
+
+  return (
+    <div className="max-w-xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold">Mod & Skin Library</h1>
+      <div className="space-y-2">
+        <Input
+          placeholder="Mod name"
+          value={form.name}
+          onChange={(e) => setForm({ ...form, name: e.target.value })}
+        />
+        <Textarea
+          placeholder="Description"
+          value={form.description}
+          onChange={(e) => setForm({ ...form, description: e.target.value })}
+        />
+        <Button onClick={addMod}>Add</Button>
+      </div>
+      <ul className="space-y-2">
+        {mods.map((mod) => (
+          <li key={mod.id} className="border p-2 rounded">
+            <div className="flex justify-between items-center">
+              <div>
+                <div className="font-semibold">{mod.name}</div>
+                <p className="text-sm">{mod.description}</p>
+              </div>
+              <div className="flex items-center gap-2">
+                <span>{mod.rating}</span>
+                <Button size="sm" onClick={() => rate(mod.id)}>
+                  +1
+                </Button>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import Image from 'next/image'
+import { useEffect, useState } from 'react'
+
+type Profile = {
+  name: string
+  avatar: string
+  inventory: { id: number; name: string; image: string }[]
+}
+
+export default function ProfilePage() {
+  const [profile, setProfile] = useState<Profile | null>(null)
+
+  useEffect(() => {
+    fetch('/api/profile')
+      .then((res) => res.json())
+      .then(setProfile)
+  }, [])
+
+  if (!profile) return <div>Loading...</div>
+
+  return (
+    <div className="max-w-md mx-auto space-y-4">
+      <h1 className="text-2xl font-bold">Profile</h1>
+      <div className="flex items-center gap-4">
+        <Image src={profile.avatar} alt={profile.name} width={64} height={64} className="rounded-full" />
+        <span className="text-xl">{profile.name}</span>
+      </div>
+      <h2 className="font-semibold">Inventory</h2>
+      <ul className="space-y-2">
+        {profile.inventory.map((item) => (
+          <li key={item.id} className="flex items-center gap-2 border p-2 rounded">
+            <Image src={item.image} alt={item.name} width={32} height={32} className="rounded" />
+            <span>{item.name}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- replace old navigation with marketplace, profile, forum, events, leaderboard, and mod library links
- add in-memory APIs and interactive pages for marketplace listings, player profiles, forum posts, event schedules, leaderboard scores, and mod sharing

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adb2dba3688325894858296bc9ea28